### PR TITLE
build: fix pre-commit hooks for server side

### DIFF
--- a/client/.husky/pre-commit
+++ b/client/.husky/pre-commit
@@ -1,3 +1,3 @@
 cd client
 echo "Running formatter with lint-staged..."
-npx lint-staged
+npx lint-staged --cwd ..

--- a/client/.lintstagedrc.cjs
+++ b/client/.lintstagedrc.cjs
@@ -1,8 +1,11 @@
+const format =
+  "prettier --config client/.prettierrc --ignore-path client/.prettierignore --ignore-path client/.gitignore --write";
+
 module.exports = {
   "*.{cjs,js,jsx,mjs,ts,tsx}": [
-    "eslint --cache --fix",
-    () => "tsc --noEmit",
-    "prettier --write",
+    "eslint --config client/eslint.config.mjs --cache --fix",
+    () => "tsc --project client --noEmit",
+    format,
   ],
-  "*.{css,json,md}": "prettier --write",
+  "*.{css,json,md}": format,
 };

--- a/server/.lintstagedrc
+++ b/server/.lintstagedrc
@@ -1,6 +1,0 @@
-{
-  "*.py": [
-    "uv run ruff check --fix --show-fixes",
-    "uv run ruff format"
-  ]
-}

--- a/server/.lintstagedrc.cjs
+++ b/server/.lintstagedrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  "*.py": [
+    "uv --project server run ruff check --fix --show-fixes",
+    "uv --project server run ruff format",
+  ],
+};
+


### PR DESCRIPTION
## Summary
<!-- Is this a bug fixing or feature --->
<!--- e.g. Bug fix #1234 -->
<!--- e.g. New feature - Added TA for xxxx -->

Update working directory of lint-staged, uv; and config file path to prettier, eslint and tsc

## Description
<!-- For each section, please include both changes to client and server, if you made changes to them. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Previously client side code can enjoy the pre-commit hooks, thus the auto formatter & linter, while it fails on the server side code. This fix is to ensure the pre-commit hooks work for both.
Turns out if the working directory is not the parent of both repos, `lint-staged` cannot correctly found its configuration files.

### Changes to Deployment
<!-- Please update accordingly. We shall update this when we have a proper backend server. For example: -->

Please re-install the pre-commit hooks to ensure it works on your side. You should see something like these if it works as intended:

```shell
$ git commit -m "test"
Running formatter with lint-staged...
✔ Backed up original state in git stash (be87dcc)
✔ Running tasks for staged files...
✔ Applying modifications from tasks...
✔ Cleaning up temporary files...
[hoteng-server-pre-commit-hooks-fix 053023a] test
 1 file changed, 1 insertion(+)
```

## How to run / test
<!-- Commands to run / test changes in your PR. For example, command to start a test server for frontend. Please update accordingly -->

To install the pre-commit hooks:

```sh
cd client
npm install  # to install and configure the hooks, and client-side tools
cd ../server
uv sync  # to install the server-side tools.
```