### PR TITLE
build: fix pre-commit hook `pytest` for server side

### DIFF
--- a/server/.lintstagedrc.cjs
+++ b/server/.lintstagedrc.cjs
@@ -3,6 +3,6 @@ module.exports = {
     "uv --project server run pyright -p server",
     "uv --project server run ruff check --fix --show-fixes",
     "uv --project server run ruff format",
-    "uv --project server run pytest"
+    () => "uv --project server run pytest -c server/pyproject.toml" // to prevent lint-staged to pass in any positional argument to interfere with pytest.
   ],
 };


### PR DESCRIPTION
<!-- Please only keep sections that are relevant. --> 

## Summary
<!-- Is this a bug fixing or feature --->
<!--- e.g. Bug fix #1234 -->
<!--- e.g. New feature - Added TA for xxxx -->
Bug fix (introduced in #88)

## Description
<!-- For each section, please include both changes to client and server, if you made changes to them. -->

Lint-staged will automatically pass-in the changed file as positional argument to the command, which will change the behaviour of `pytest`. The new change prevents this behaviour and always run the full set of unit-tests.

## How to run / test
<!-- Commands to run / test changes in your PR. For example, command to start a test server for frontend. Please update accordingly -->

1. With `uv` installed in `PATH`.
2. With pre-commit hook correctly set-up

```sh
cd client
npm install
```

3. Change anything a little in any Python scripts under `server`, stage it and try to commit with `git`.
