### PR TITLE
Fix number input with comma to be evaluated to NaN, enable optional parameters empty input values

### DIFF
--- a/client/src/types/module.ts
+++ b/client/src/types/module.ts
@@ -1,4 +1,4 @@
-export type ParamValueType = string | number | boolean;
+export type ParamValueType = string | number | boolean | null;
 export type ParamConstraintsType = "str" | "int" | "select" | "bool";
 export const ALLOWED_FRAME_RATES = [
   "23.976",

--- a/server/app/modules/generic/binary_module.py
+++ b/server/app/modules/generic/binary_module.py
@@ -133,6 +133,8 @@ class GenericBinaryModule(ModuleBase):
                     if required:
                         raise ValueError(f"Missing required parameter: {name}")
                     continue
+                elif parameters[name] is None:
+                    continue
                 value = parameters[name]
 
             # Boolean flags (e.g., --verbose)

--- a/server/app/schemas/pipeline.py
+++ b/server/app/schemas/pipeline.py
@@ -7,7 +7,7 @@ from typing import Any
 
 class PipelineParameter(BaseModel):
     key: str
-    value: int | float | str | bool
+    value: int | float | str | bool | None
 
 
 class PipelineModule(BaseModel):


### PR DESCRIPTION
<!-- Please only keep sections that are relevant. --> 

## Summary
Bug fixes https://github.com/JoeyTeng/mmrp/issues/112 and https://github.com/JoeyTeng/mmrp/issues/105


## Description
<!-- For each section, please include both changes to client and server, if you made changes to them. -->
Refactored the number input handling to correctly parse and clamp numeric values, avoiding issues caused by commas.
Allowed optional parameters in the configuration panel to remain empty, preventing automatic default values (like 0) from being set and avoiding unintended behaviour.

### Screenshots
<!-- Keep this section only when there's any UI change to the client / web page. -->
Number input value properly evaluated without comma
<img width="1912" height="898" alt="comma fixed" src="https://github.com/user-attachments/assets/40851ecb-a637-4945-8b63-7ee1b03bf72b" />

Possibility to leave optional fields empty
<img width="1918" height="912" alt="optional parameters" src="https://github.com/user-attachments/assets/9d14057b-d7d3-4a83-9a23-d6288d7d3d97" />




