### PR TITLE
Prevent Interleaving Frames view if videos shapes mismatch

### DIFF
--- a/client/src/components/cards/VideoComparisonView.tsx
+++ b/client/src/components/cards/VideoComparisonView.tsx
@@ -6,15 +6,15 @@ import MenuDropdown from "@/components/comparison-view/MenuDropdown";
 import { Box, Checkbox, FormControlLabel, Typography } from "@mui/material";
 import { VideoType, ViewOptions } from "@/components/comparison-view/types";
 import { useVideoReload } from "@/contexts/VideoReloadContext";
-import { useState } from "react";
 import { useFrames } from "@/contexts/FramesContext";
 
 const VideoComparisonView = () => {
-  const [view, setView] = useState(ViewOptions.SideBySide);
   const {
     selectedVideoType,
     setSelectedVideoType,
     activeVideoType,
+    view,
+    setView,
     isProcessing,
   } = useVideoReload();
   const { isStreamActive } = useFrames();

--- a/client/src/components/comparison-view/MenuDropdown.tsx
+++ b/client/src/components/comparison-view/MenuDropdown.tsx
@@ -17,7 +17,7 @@ const MenuDropdown = ({ onSelect }: MenuDropdownProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
-  const { isPipelineRun } = useVideoReload();
+  const { isPipelineRun, videoShapesMismatch } = useVideoReload();
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -26,7 +26,6 @@ const MenuDropdown = ({ onSelect }: MenuDropdownProps) => {
   const handleClose = () => setAnchorEl(null);
 
   const handleSelection = (view: ViewOptions) => {
-    console.log(isPipelineRun);
     onSelect(view);
     handleClose();
   };
@@ -47,7 +46,8 @@ const MenuDropdown = ({ onSelect }: MenuDropdownProps) => {
         </ListSubheader>
         {Object.values(ViewOptions).map((option) => {
           const disabled =
-            option === ViewOptions.Interleaving && !isPipelineRun;
+            option === ViewOptions.Interleaving &&
+            (!isPipelineRun || videoShapesMismatch);
           return (
             <MenuItem
               dense

--- a/client/src/contexts/VideoReloadContext.tsx
+++ b/client/src/contexts/VideoReloadContext.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import type { PipelineRequest, PipelineResponse } from "@/types/pipeline";
 import { useVideoMetrics } from "./VideoMetricsContext";
-import { VideoType } from "@/components/comparison-view/types";
+import { VideoType, ViewOptions } from "@/components/comparison-view/types";
 
 type VideoReloadContextType = {
   triggerReload: (res: PipelineResponse) => void;
@@ -32,8 +32,12 @@ type VideoReloadContextType = {
   activeVideoType: VideoType;
   selectedVideoType: VideoType;
   setSelectedVideoType: React.Dispatch<React.SetStateAction<VideoType>>;
+  view: ViewOptions;
+  setView: React.Dispatch<React.SetStateAction<ViewOptions>>;
   handlePipelineRun: () => void;
   isPipelineRun: boolean;
+  videoShapesMismatch: boolean;
+  setVideoShapesMismatch: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const VideoReloadContext = createContext<VideoReloadContextType | undefined>(
@@ -81,13 +85,20 @@ export const VideoReloadProvider = ({ children }: { children: ReactNode }) => {
     },
     [],
   );
+  const [view, setView] = useState(ViewOptions.SideBySide);
   const [selectedVideoType, setSelectedVideoType] = useState(VideoType.Video);
   const [activeVideoType, setActiveVideoType] = useState(VideoType.Video);
+  const [videoShapesMismatch, setVideoShapesMismatch] = useState(false);
 
   const triggerReload = (res: PipelineResponse) => {
     setLatestResponse(res);
     setCurrentFrame(0);
     setMetrics(res.metrics);
+    console.log(res);
+    if (res.interleaved === "") {
+      setVideoShapesMismatch(true);
+      setView(ViewOptions.SideBySide);
+    }
   };
 
   const triggerWebSocketConnection = (req: PipelineRequest) => {
@@ -98,6 +109,7 @@ export const VideoReloadProvider = ({ children }: { children: ReactNode }) => {
     setMetrics([]);
     setActiveVideoType(selectedVideoType);
     setIsPipelineRun(true);
+    setVideoShapesMismatch(false);
   };
 
   return (
@@ -116,8 +128,12 @@ export const VideoReloadProvider = ({ children }: { children: ReactNode }) => {
         activeVideoType,
         selectedVideoType,
         setSelectedVideoType,
+        view,
+        setView,
         handlePipelineRun,
         isPipelineRun,
+        videoShapesMismatch,
+        setVideoShapesMismatch,
       }}
     >
       {children}

--- a/server/app/services/pipeline.py
+++ b/server/app/services/pipeline.py
@@ -163,6 +163,7 @@ def handle_pipeline_request(request: PipelineRequest) -> PipelineResponse:
     )
 
     metrics: list[Metrics] = []
+    shape_mismatch = False
 
     with module_map[source_mod.id][0].process(None, module_map[source_mod.id][1]) as (
         source_file,
@@ -171,6 +172,7 @@ def handle_pipeline_request(request: PipelineRequest) -> PipelineResponse:
     ):
         # Run frames through whole pipeline and return the frames that need to be written
         def base_pipeline_iterator() -> Iterator[tuple[str, np.ndarray]]:
+            nonlocal shape_mismatch
             frame_cache: dict[str, np.ndarray] = {}
             for frame in frame_iter:
                 frame_cache.clear()
@@ -183,6 +185,8 @@ def handle_pipeline_request(request: PipelineRequest) -> PipelineResponse:
                 # Compute quality metrics
                 if len(result_modules) == 1:
                     processed_frame = frame_cache[result_modules[0].source[0]]
+                    if original_frame.shape != processed_frame.shape:
+                        shape_mismatch = True
                     metrics.append(
                         compute_frame_metrics(original_frame, processed_frame)
                     )
@@ -192,6 +196,8 @@ def handle_pipeline_request(request: PipelineRequest) -> PipelineResponse:
                 else:
                     f1 = frame_cache[result_modules[0].source[0]]
                     f2 = frame_cache[result_modules[1].source[0]]
+                    if f1.shape != f2.shape:
+                        shape_mismatch = True
                     metrics.append(compute_frame_metrics(f1, f2))
                     yield result_modules[0].id, f1
                     yield result_modules[1].id, f2
@@ -264,23 +270,22 @@ def handle_pipeline_request(request: PipelineRequest) -> PipelineResponse:
             mod_instance.process(output_iters[result_mod.id], params)
             outputs.append({"video_player": params["video_player"], "path": filename})
 
-        # Write interleaved video output
-        interleaved_mod = ModuleRegistry.get_by_spacename(ModuleName.RESULT)
-        # Create video file name
-        unique_id = uuid.uuid4()
-        filename_base64 = (
-            base64.urlsafe_b64encode(unique_id.bytes).decode("utf-8").rstrip("=")
-        )
-        filename = f"{source_file}-{filename_base64}.webm"
-        interleaved_params: dict[str, Any] = {
-            "path": filename,
-            "fps": fps,
-            "video_player": "interleaved",
-        }
-        interleaved_mod.process(interleaved_iterator(), interleaved_params)
-        outputs.append(
-            {"video_player": "interleaved", "path": interleaved_params["path"]}
-        )
+        if not shape_mismatch:
+            interleaved_mod = ModuleRegistry.get_by_spacename(ModuleName.RESULT)
+            unique_id = uuid.uuid4()
+            filename_base64 = (
+                base64.urlsafe_b64encode(unique_id.bytes).decode("utf-8").rstrip("=")
+            )
+            filename = f"{source_file}-{filename_base64}.webm"
+            interleaved_params: dict[str, Any] = {
+                "path": filename,
+                "fps": fps,
+                "video_player": "interleaved",
+            }
+            interleaved_mod.process(interleaved_iterator(), interleaved_params)
+            outputs.append(
+                {"video_player": "interleaved", "path": interleaved_params["path"]}
+            )
 
         output_map = {entry["video_player"]: entry["path"] for entry in outputs}
         response = PipelineResponse(


### PR DESCRIPTION
<!-- Please only keep sections that are relevant. --> 

## Summary
Bug fix https://github.com/JoeyTeng/mmrp/issues/121

## Description
Interleaving frames video requires frames to have matching shapes. If the frames do not match, the interleaved video is not displayed, the menu option is disabled, and the view defaults to Side by Side
