### PR TITLE
Bug/fix video display overflow error

### DIFF
--- a/client/src/components/comparison-view/InterleavingFrames.tsx
+++ b/client/src/components/comparison-view/InterleavingFrames.tsx
@@ -115,25 +115,29 @@ const InterleavingFrames = ({ type }: Props) => {
         )}
         {type === VideoType.Video && videoRef && (
           <>
-            <Box
-              component="video"
-              ref={videoRef}
-              className={`h-full w-auto object-contain`}
-              onTimeUpdate={() => playerRef.current?.handleTimeUpdate()}
-              onLoadStart={() => setIsLoading(true)}
-              onCanPlay={() => setIsLoading(false)}
-              onError={() => setError("Failed to load video")}
-              controls={false}
-            />
+            <Box className="w-1/2 flex items-center justify-center bg-black">
+              <Box
+                component="video"
+                ref={videoRef}
+                className="max-w-full max-h-full object-contain"
+                onTimeUpdate={() => playerRef.current?.handleTimeUpdate()}
+                onLoadStart={() => setIsLoading(true)}
+                onCanPlay={() => setIsLoading(false)}
+                onError={() => setError("Failed to load video")}
+                controls={false}
+              />
+            </Box>
           </>
         )}
         {type === VideoType.Stream && (
           <>
-            <Box
-              component="canvas"
-              ref={canvasRef}
-              className={`h-full w-auto object-contain`}
-            />
+            <Box className="w-1/2 flex items-center justify-center bg-black">
+              <Box
+                component="canvas"
+                ref={canvasRef}
+                className="max-w-full max-h-full object-contain"
+              />
+            </Box>
           </>
         )}
       </Box>

--- a/client/src/components/comparison-view/SideBySide.tsx
+++ b/client/src/components/comparison-view/SideBySide.tsx
@@ -153,37 +153,47 @@ const SideBySide = ({ type }: Props) => {
         {type === VideoType.Video && (
           <>
             {/* Left Video */}
-            <Box
-              component="video"
-              ref={videoARef}
-              className="w-1/2 h-full object-contain"
-              onTimeUpdate={() => playerRef.current?.handleTimeUpdate()}
-              onLoadStart={() => setIsLoading(true)}
-              onCanPlay={() => setIsLoading(false)}
-              onError={() => setError("Failed to load original video")}
-            />
+            <Box className="w-1/2 flex items-center justify-center bg-black">
+              <Box
+                component="video"
+                ref={videoARef}
+                className="max-w-full max-h-full object-contain"
+                onTimeUpdate={() => playerRef.current?.handleTimeUpdate()}
+                onLoadStart={() => setIsLoading(true)}
+                onCanPlay={() => setIsLoading(false)}
+                onError={() => setError("Failed to load original video")}
+              />
+            </Box>
             {/* Right Video */}
-            <Box
-              component="video"
-              ref={videoBRef}
-              className="w-1/2 h-full object-contain"
-              muted
-              onError={() => setError("Failed to load filtered video")}
-            />
+
+            <Box className="w-1/2 flex items-center justify-center bg-black">
+              <Box
+                component="video"
+                ref={videoBRef}
+                className="max-w-full max-h-full object-contain"
+                muted
+                onError={() => setError("Failed to load filtered video")}
+              />
+            </Box>
           </>
         )}
         {type === VideoType.Stream && (
           <>
-            <Box
-              component="canvas"
-              ref={canvasARef}
-              className="w-1/2 h-full bg-black object-contain"
-            />
-            <Box
-              component="canvas"
-              ref={canvasBRef}
-              className="w-1/2 h-full bg-black object-contain"
-            />
+            <Box className="w-1/2 flex items-center justify-center bg-black">
+              <Box
+                component="canvas"
+                ref={canvasARef}
+                className="max-w-full max-h-full object-contain"
+              />
+            </Box>
+
+            <Box className="w-1/2 flex items-center justify-center bg-black">
+              <Box
+                component="canvas"
+                ref={canvasBRef}
+                className="max-w-full max-h-full object-contain"
+              />
+            </Box>
           </>
         )}
       </Box>

--- a/client/src/contexts/VideoReloadContext.tsx
+++ b/client/src/contexts/VideoReloadContext.tsx
@@ -94,7 +94,6 @@ export const VideoReloadProvider = ({ children }: { children: ReactNode }) => {
     setLatestResponse(res);
     setCurrentFrame(0);
     setMetrics(res.metrics);
-    console.log(res);
     if (res.interleaved === "") {
       setVideoShapesMismatch(true);
       setView(ViewOptions.SideBySide);


### PR DESCRIPTION
<!-- Please only keep sections that are relevant. --> 

## Summary
Bug fix – Video player scaling issue

## Description
Fix video overflow and distortion when displaying videos of varying resolutions in the side-by-side player.  

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Screenshots
<img width="2387" height="2807" alt="image" src="https://github.com/user-attachments/assets/8c91a4fb-5148-4179-b1f2-5b942241fa11" />

<img width="2388" height="2806" alt="image" src="https://github.com/user-attachments/assets/a60512b1-d827-483b-bac1-bb376d7a97cf" />

### Functionality Changes
UX improvement – videos now adapt responsively to container size, maintaining aspect ratio.

