### PR TITLE
fix: Cisco open source compliance

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-hoteng@cisco.com or fpihl@cisco.com. All complaints will be reviewed and investigated
+oss-conduct@cisco.com. All complaints will be reviewed and investigated
 promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+hoteng@cisco.com or fpihl@cisco.com. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# How to Contribute
+
+Thanks for your interest in contributing to `Cisco VIPER: VIsual Pipeline EditoR`! Here are a few
+general guidelines on contributing and reporting bugs that we ask you to review.
+Following these guidelines helps to communicate that you respect the time of the
+contributors managing and developing this open source project. In return, they
+should reciprocate that respect in addressing your issue, assessing changes, and
+helping you finalize your pull requests. In that spirit of mutual respect, we
+endeavor to review incoming issues and pull requests within 10 days, and will
+close any lingering issues or pull requests after 60 days of inactivity.
+
+Please note that all of your interactions in the project are subject to our
+[Code of Conduct](/CODE_OF_CONDUCT.md). This includes creation of issues or pull
+requests, commenting on issues or pull requests, and extends to all interactions
+in any real-time space e.g., Slack, Discord, etc.
+
+## Reporting Issues
+
+Before reporting a new issue, please ensure that the issue was not already
+reported or fixed by searching through our [issues
+list](https://github.com/JoeyTeng/mmrp/issues).
+
+When creating a new issue, please be sure to include a **title and clear
+description**, as much relevant information as possible, and, if possible, a
+test case.
+
+**If you discover a security bug, please do not report it through GitHub.
+Instead, please see security procedures in [SECURITY.md](/SECURITY.md).**
+
+## Sending Pull Requests
+
+Before sending a new pull request, take a look at existing pull requests and
+issues to see if the proposed change or fix has been discussed in the past, or
+if the change was already implemented but not yet released.
+
+We expect new pull requests to include tests for any affected behavior, and, as
+we follow semantic versioning, we may reserve breaking changes until the next
+major version release.
+
+## Other Ways to Contribute
+
+We welcome anyone that wants to contribute to `Cisco VIPER: VIsual Pipeline EditoR` to triage and
+reply to open issues to help troubleshoot and fix existing bugs. Here is what
+you can do:
+
+- Help ensure that existing issues follows the recommendations from the
+  _[Reporting Issues](#reporting-issues)_ section, providing feedback to the
+  issue's author on what might be missing.
+- Review and update the existing content of our
+  [Wiki](https://github.com/JoeyTeng/mmrp/wiki) with up-to-date
+  instructions and code samples.
+- Review existing pull requests, and testing patches against real existing
+  applications that use `Cisco VIPER: VIsual Pipeline EditoR`.
+- Write a test, or add a missing test case to an existing test.
+
+Thanks again for your interest on contributing to `Cisco VIPER: VIsual Pipeline EditoR`!
+
+:heart:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,64 +1,107 @@
-# Cisco VIPER: VIsual Pipeline EditoR
+# MMRP: Multimedia Research Pipeline
 
-## Contributors
+[![Contributor-Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-fbab2c.svg)](CODE_OF_CONDUCT.md)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.md)
+[![Maintainer](https://img.shields.io/badge/Maintainer-Cisco-00bceb.svg)](https://opensource.cisco.com)
 
-Fredrik Pihl, Hongyu Teng, Everly Precia Suresh Kumar, Romy Sophia Richter, Ana Georgieska, Brandon Alexander and Frank Cruz.
+MMRP (Multimedia Research Pipeline) is a visual pipeline editor designed for building and experimenting with multimedia processing workflows. It provides an intuitive drag-and-drop interface for creating complex video processing pipelines with real-time preview and comparison capabilities.
 
-## Contribution
+## About The Project
 
-### Client
+MMRP enables researchers and developers to:
 
-Please install the precommit hooks for automatic linting and formatting:
+- **Visually design** multimedia processing pipelines using a node-based editor
+- **Compare video outputs** side-by-side with multiple viewing modes (split-screen, interleaving, unified player)
+- **Analyze quality metrics** including PSNR, SSIM, MSE, and VMAF
+- **Export and share** pipeline configurations for reproducibility
+- **Process frames** through customizable transformation modules
 
-```bash
-cd client
-npm install
-```
+The project consists of a React/Next.js frontend providing the visual editor interface and a FastAPI backend handling video processing, pipeline execution, and quality metric calculations.
 
-## How to Run
+## Getting Started
 
-### Frontend
+To get a local copy up and running, follow these steps.
 
-```sh
-cd client
-npm install
-npm run build
-npm run start
-```
+### Prerequisites
 
-### Backend
+- **Node.js** (v20 or higher) and npm
+- **Python** (v3.13 or higher)
+- **uv** (Python package manager) - Install via:
+  ```sh
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  ```
 
-```sh
-cd server
+### Installation
 
-uv run uvicorn main:app --reload
-```
+1. Clone the repository
+   ```sh
+   git clone https://github.com/JoeyTeng/mmrp.git
+   cd mmrp
+   ```
 
-### Scripts
+2. Set up the frontend
+   ```sh
+   cd client
+   npm install
+   npm run build
+   ```
 
-There are also two scripts that can be used for deployment. You can deploy the server in the VM, the project is already installed there (inside test/mmrp).
+3. Set up the backend
+   ```sh
+   cd ../server
+   uv sync
+   ```
 
-#### Preparing the environment
-This will install all dependencies and build the client.
+### Quick Start with Scripts
 
+For streamlined deployment, use the provided scripts:
+
+#### Preparing the Environment
+Install all dependencies and build the client:
 ```sh
 ./scripts/setup.sh
 ```
 
-#### Starting the server
-This will run the server. Once the server is deployed, you can run the application on `http://<VM_IP>:8000/` as long as you are connected to the VPN. You can also pass command line arguments to the script (for example `--workers 2`).
-
+#### Starting the Server
+Run the server (supports command-line arguments like `--workers 2`):
 ```sh
 ./scripts/run.sh
 ```
 
-## Creating your own example pipeline configurations
+The application will be available at `http://localhost:8000/`
 
-### Convert from Exported JSON
-Draw the needed example configuration on the canvas and export it. When you export, the JSON contains extra frontend data that needs to be removed. To convert to Target JSON for storing in the backend, follow the steps below:
+## Usage
 
-#### 1. Remove wrapper metadata
+### Running the Application
 
+#### Frontend Development Mode
+```sh
+cd client
+npm run dev
+```
+Access the development server at `http://localhost:3000/`
+
+#### Backend Development Mode
+```sh
+cd server
+uv run uvicorn main:app --reload
+```
+The API will be available at `http://localhost:8000/`
+
+#### Production Deployment
+```sh
+cd client
+npm run build
+npm run start
+```
+
+### Creating Pipeline Configurations
+
+#### Exporting Pipelines
+
+Draw your pipeline configuration on the canvas and export it. The exported JSON needs conversion to the backend format:
+
+**Exported JSON format:**
 ```json
 {
   "metadata": { "version": "1.0", "timestamp": "" },
@@ -66,8 +109,7 @@ Draw the needed example configuration on the canvas and export it. When you expo
 }
 ```
 
-**Target JSON**:
-
+**Target backend format:**
 ```json
 {
   "name": "My Pipeline",
@@ -76,33 +118,91 @@ Draw the needed example configuration on the canvas and export it. When you expo
 }
 ```
 
-#### 2. Rename keys (camelCase -> snake\_case)
+#### Conversion Steps
 
-Convert field names:
+1. **Remove wrapper metadata** - Extract the `nodes` and `edges` from the `data` field
+2. **Rename keys** (camelCase → snake_case):
+   - `moduleClass` → `module_class`
+   - `inputFormats` → `input_formats`
+   - `outputFormats` → `output_formats`
+   - `pixelFormat` → `pixel_format`
+   - `colorSpace` → `color_space`
+3. **Drop UI-only fields** - Remove frontend-specific properties like `measured`, `flag`, `options` (outside `constraints`)
+4. **Clean up edges** - Ensure edges only contain:
+   ```json
+   {
+     "id": "e1-e2",
+     "source": "n1",
+     "target": "n2",
+     "sourceHandle": "output-0-handle",
+     "targetHandle": "input-0-handle"
+   }
+   ```
 
-* `moduleClass` -> `module_class`
-* `inputFormats` -> `input_formats`
-* `outputFormats` -> `output_formats`
-* `pixelFormat` -> `pixel_format`
-* `colorSpace` -> `color_space`  
-and so on.
+### Video Comparison Features
 
-#### 3. Drop UI-only fields
+- **Side-by-Side View**: Compare two video streams simultaneously
+- **Interleaving Frames**: Alternate between frames from different sources
+- **Unified Player**: View multiple outputs in a single player
+- **Quality Metrics**: Real-time PSNR, SSIM, MSE, and VMAF calculations
 
-Remove properties that are frontend-only, e.g.:
+## Development
 
-* `measured`, `flag`, `options` (outside `constraints`), etc.
+### Frontend
 
-#### 4. Edges
+The frontend uses:
+- **Next.js 15** with React 19
+- **TypeScript** for type safety
+- **Material-UI** and **Tailwind CSS** for styling
+- **React Flow** for the node-based editor
+- **Jest** for unit testing
 
-Ensure edges expose the following keys and remove other excess keys:
-
-```json
-{
-  "id": "e1-e2",
-  "source": "n1",
-  "target": "n2",
-  "sourceHandle": "output-0-handle",
-  "targetHandle": "input-0-handle"
-}
+Install pre-commit hooks for automatic linting and formatting:
+```sh
+cd client
+npm install
 ```
+
+Run tests:
+```sh
+npm run test:unit
+npm run coverage:unit
+```
+
+### Backend
+
+The backend uses:
+- **FastAPI** for the REST API
+- **OpenCV** for video processing
+- **NumPy** and **scikit-image** for image operations
+- **Pydantic** for data validation
+- **pytest** for testing
+
+Run tests:
+```sh
+cd server
+uv run pytest
+uv run pytest --cov
+```
+
+## Roadmap
+
+See the [open issues](https://github.com/JoeyTeng/mmrp/issues) for a list of proposed features and known issues.
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**. 
+
+For detailed contributing guidelines, please see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## License
+
+Distributed under the Apache License 2.0. See [LICENSE.md](LICENSE.md) for more information.
+
+## Acknowledgements
+
+**Contributors:** Fredrik Pihl, Hongyu Teng, Everly Precia Suresh Kumar, Romy Sophia Richter, Ana Georgieska, Brandon Alexander, and Frank Cruz.
+
+## Contact
+
+Project Link: [https://github.com/JoeyTeng/mmrp](https://github.com/JoeyTeng/mmrp)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the
+`Cisco VIPER: VIsual Pipeline EditoR` project.
+
+- [Disclosing a security issue](#disclosing-a-security-issue)
+- [Vulnerability management](#vulnerability-management)
+- [Suggesting changes](#suggesting-changes)
+
+## Disclosing a security issue
+
+The `Cisco VIPER: VIsual Pipeline EditoR` maintainers take all security issues in the project
+seriously. Thank you for improving the security of `Cisco VIPER: VIsual Pipeline EditoR`. We
+appreciate your dedication to responsible disclosure and will make every effort
+to acknowledge your contributions.
+
+`Cisco VIPER: VIsual Pipeline EditoR` leverages GitHub's private vulnerability reporting.
+
+To learn more about this feature and how to submit a vulnerability report,
+review [GitHub's documentation on private reporting](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+
+Here are some helpful details to include in your report:
+
+- a detailed description of the issue
+- the steps required to reproduce the issue
+- versions of the project that may be affected by the issue
+- if known, any mitigations for the issue
+
+A maintainer will acknowledge the report within three (3) business days, and
+will send a more detailed response within an additional three (3) business days
+indicating the next steps in handling your report.
+
+If you've been unable to successfully draft a vulnerability report via GitHub
+or have not received a response during the alloted response window, please
+reach out via the [Cisco Open security contact email](mailto:oss-security@cisco.com).
+
+After the initial reply to your report, the maintainers will endeavor to keep
+you informed of the progress towards a fix and full announcement, and may ask
+for additional information or guidance.
+
+## Vulnerability management
+
+When the maintainers receive a disclosure report, they will assign it to a
+primary handler.
+
+This person will coordinate the fix and release process, which involves the
+following steps:
+
+- confirming the issue
+- determining affected versions of the project
+- auditing code to find any potential similar problems
+- preparing fixes for all releases under maintenance
+
+## Suggesting changes
+
+If you have suggestions on how this process could be improved please submit an
+issue or pull request.

--- a/client/jest.config.ts
+++ b/client/jest.config.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import nextJest from "next/jest";
 import type { Config } from "jest";
 

--- a/client/jest.setup.ts
+++ b/client/jest.setup.ts
@@ -1,1 +1,5 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import "@testing-library/jest-dom";

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2025 Cisco Systems, Inc. and its affiliates
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @layer theme, base, mui, components, utilities;
 @import "tailwindcss";
 @import "@xyflow/react/dist/style.css";

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import "./globals.css";
 import { Suspense } from "react";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter";

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import DragAndDropArea from "@/components/cards/DragAndDropArea";
 import AppLayout from "@/components/layout/AppLayout";
 import { Box } from "@mui/material";

--- a/client/src/components/cards/DragAndDropArea.tsx
+++ b/client/src/components/cards/DragAndDropArea.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import FlowCanvas from "@/components/drag-and-drop/FlowCanvas";

--- a/client/src/components/cards/VideoComparisonView.tsx
+++ b/client/src/components/cards/VideoComparisonView.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState } from "react";

--- a/client/src/components/comparison-metrics/VideoQualityMetrics.tsx
+++ b/client/src/components/comparison-metrics/VideoQualityMetrics.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useVideoMetrics } from "@/contexts/VideoMetricsContext";
 import { Box } from "@mui/material";
 import { useMemo } from "react";

--- a/client/src/components/comparison-view/FrameStreamPlayer.tsx
+++ b/client/src/components/comparison-view/FrameStreamPlayer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React, { useCallback, useEffect, useRef, useState } from "react";

--- a/client/src/components/comparison-view/InterleavingFrames.tsx
+++ b/client/src/components/comparison-view/InterleavingFrames.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useEffect, useRef, useState } from "react";

--- a/client/src/components/comparison-view/MenuDropdown.tsx
+++ b/client/src/components/comparison-view/MenuDropdown.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState } from "react";

--- a/client/src/components/comparison-view/PlayerControls.tsx
+++ b/client/src/components/comparison-view/PlayerControls.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import {

--- a/client/src/components/comparison-view/SideBySide.tsx
+++ b/client/src/components/comparison-view/SideBySide.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useRef, useEffect } from "react";

--- a/client/src/components/comparison-view/UnifiedPlayer.tsx
+++ b/client/src/components/comparison-view/UnifiedPlayer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React from "react";

--- a/client/src/components/comparison-view/VideoPlayer.tsx
+++ b/client/src/components/comparison-view/VideoPlayer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React, {

--- a/client/src/components/comparison-view/types.ts
+++ b/client/src/components/comparison-view/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Metrics } from "@/types/metrics";
 
 export enum ViewOptions {

--- a/client/src/components/drag-and-drop/ExamplePipelines.tsx
+++ b/client/src/components/drag-and-drop/ExamplePipelines.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useReactFlow } from "@xyflow/react";

--- a/client/src/components/drag-and-drop/FlowCanvas.tsx
+++ b/client/src/components/drag-and-drop/FlowCanvas.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React, { useCallback, useRef, useMemo, useState } from "react";

--- a/client/src/components/drag-and-drop/FlowNode.tsx
+++ b/client/src/components/drag-and-drop/FlowNode.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Handle, Node, NodeProps, Position } from "@xyflow/react";

--- a/client/src/components/drag-and-drop/ModuleItem.tsx
+++ b/client/src/components/drag-and-drop/ModuleItem.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 import { Box } from "@mui/material";
 import { Module } from "@/types/module";

--- a/client/src/components/drag-and-drop/ModuleItemGroup.tsx
+++ b/client/src/components/drag-and-drop/ModuleItemGroup.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Divider } from "@mui/material";
 import ModuleItem from "./ModuleItem";
 import { Module } from "@/types/module";

--- a/client/src/components/drag-and-drop/Modules.tsx
+++ b/client/src/components/drag-and-drop/Modules.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Divider, InputAdornment, Stack, TextField } from "@mui/material";
 import { useMemo, useState } from "react";
 import { useModulesContext } from "@/contexts/ModulesContext";

--- a/client/src/components/drag-and-drop/context-menu/CanvasContextMenu.tsx
+++ b/client/src/components/drag-and-drop/context-menu/CanvasContextMenu.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useCallback, useImperativeHandle, useRef, useState } from "react";
 import { useCanvasActions } from "./useCanvasActions";
 import {

--- a/client/src/components/drag-and-drop/context-menu/CanvasContextMenuConfig.tsx
+++ b/client/src/components/drag-and-drop/context-menu/CanvasContextMenuConfig.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   Add,
   DeleteOutlined,

--- a/client/src/components/drag-and-drop/context-menu/NodeContextMenu.tsx
+++ b/client/src/components/drag-and-drop/context-menu/NodeContextMenu.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   useCallback,
   useImperativeHandle,

--- a/client/src/components/drag-and-drop/context-menu/NodeContextMenuConfig.tsx
+++ b/client/src/components/drag-and-drop/context-menu/NodeContextMenuConfig.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ContextMenuItem } from "@/components/util/types";
 import {
   FileCopyOutlined,

--- a/client/src/components/drag-and-drop/context-menu/useCanvasActions.ts
+++ b/client/src/components/drag-and-drop/context-menu/useCanvasActions.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useCallback, useContext } from "react";
 import { CanvasContextAction } from "./CanvasContextMenuConfig";
 import { useReactFlow } from "@xyflow/react";

--- a/client/src/components/drag-and-drop/context-menu/useNodeActions.ts
+++ b/client/src/components/drag-and-drop/context-menu/useNodeActions.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useReactFlow, Node, Edge, getConnectedEdges } from "@xyflow/react";
 import { NodeAction } from "./NodeContextMenuConfig";
 import { useCallback } from "react";

--- a/client/src/components/drag-and-drop/parameter-configuration/ParameterConfiguration.tsx
+++ b/client/src/components/drag-and-drop/parameter-configuration/ParameterConfiguration.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useMemo } from "react";

--- a/client/src/components/drag-and-drop/parameter-configuration/ParameterConfigurationDrawer.tsx
+++ b/client/src/components/drag-and-drop/parameter-configuration/ParameterConfigurationDrawer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useCallback, useEffect, useState } from "react";

--- a/client/src/components/drag-and-drop/parameter-configuration/ParameterTooltip.tsx
+++ b/client/src/components/drag-and-drop/parameter-configuration/ParameterTooltip.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import Tooltip from "@mui/material/Tooltip";
 import { ReactElement } from "react";
 

--- a/client/src/components/drag-and-drop/types.ts
+++ b/client/src/components/drag-and-drop/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Node } from "@xyflow/react";
 import { ParamValueType, ModuleType, ModuleData } from "@/types/module";
 

--- a/client/src/components/drag-and-drop/util.ts
+++ b/client/src/components/drag-and-drop/util.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Edge, Node } from "@xyflow/react";
 import { ModuleData, ModuleParameter, ModuleType } from "@/types/module";
 import { displayError } from "@/utils/sharedFunctionality";

--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 import { useState } from "react";
 import { Sidebar } from "../sidebar/Sidebar";

--- a/client/src/components/layout/Loading.tsx
+++ b/client/src/components/layout/Loading.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Box, CircularProgress } from "@mui/material";

--- a/client/src/components/modals/DualFileRow.tsx
+++ b/client/src/components/modals/DualFileRow.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Button, Typography, Paper, Box } from "@mui/material";

--- a/client/src/components/modals/SingleFileRow.tsx
+++ b/client/src/components/modals/SingleFileRow.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Button, Typography, Paper, Box } from "@mui/material";

--- a/client/src/components/modals/UploadBinaryModal.tsx
+++ b/client/src/components/modals/UploadBinaryModal.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Button, Box } from "@mui/material";

--- a/client/src/components/sidebar/AppDrawer.tsx
+++ b/client/src/components/sidebar/AppDrawer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Drawer, Typography, Box, IconButton } from "@mui/material";

--- a/client/src/components/sidebar/LeftSidebar.tsx
+++ b/client/src/components/sidebar/LeftSidebar.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useVideoReload } from "@/contexts/VideoReloadContext";

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 import { Drawer, List, Divider, Box } from "@mui/material";
 import { SidebarItem } from "./SidebarItem";

--- a/client/src/components/sidebar/SidebarItem.tsx
+++ b/client/src/components/sidebar/SidebarItem.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   ListItem,
   ListItemButton,

--- a/client/src/components/sidebar/SidebarPanel.tsx
+++ b/client/src/components/sidebar/SidebarPanel.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Paper, Typography, IconButton, Box } from "@mui/material";
 import { Close } from "@mui/icons-material";
 import { SidebarPanelProps } from "./types";

--- a/client/src/components/sidebar/sidebar-config.tsx
+++ b/client/src/components/sidebar/sidebar-config.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   QueryStatsOutlined,
   FilterAltOutlined,

--- a/client/src/components/sidebar/types.ts
+++ b/client/src/components/sidebar/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { SxProps, Theme } from "@mui/material";
 import { ReactNode } from "react";
 

--- a/client/src/components/sidebar/util.ts
+++ b/client/src/components/sidebar/util.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useMemo } from "react";
 import { useVideoReload } from "@/contexts/VideoReloadContext";
 import { toast } from "react-toastify/unstyled";

--- a/client/src/components/util/ContextMenu.tsx
+++ b/client/src/components/util/ContextMenu.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { ListItemIcon, ListItemText, Divider } from "@mui/material";

--- a/client/src/components/util/GenericModal.tsx
+++ b/client/src/components/util/GenericModal.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import {

--- a/client/src/components/util/types.ts
+++ b/client/src/components/util/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ButtonOwnProps } from "@mui/material";
 
 export type ContextMenuItem<ActionType extends string> = {

--- a/client/src/contexts/AppProviders.tsx
+++ b/client/src/contexts/AppProviders.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ReactNode } from "react";
 import { VideoMetricsProvider } from "./VideoMetricsContext";
 import { VideoReloadProvider } from "./VideoReloadContext";

--- a/client/src/contexts/ExamplePipelinesContext.tsx
+++ b/client/src/contexts/ExamplePipelinesContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { createContext, useMemo, ReactNode, useContext } from "react";

--- a/client/src/contexts/ModulesContext.tsx
+++ b/client/src/contexts/ModulesContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useModules } from "@/hooks/useModule";

--- a/client/src/contexts/SidebarContext.tsx
+++ b/client/src/contexts/SidebarContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { createContext } from "react";
 
 type SidebarContextValue = {

--- a/client/src/contexts/VideoMetricsContext.tsx
+++ b/client/src/contexts/VideoMetricsContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 import { Metrics } from "@/types/metrics";
 import React, { createContext, useContext, useState } from "react";

--- a/client/src/contexts/VideoReloadContext.tsx
+++ b/client/src/contexts/VideoReloadContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import {

--- a/client/src/contexts/WebSocketContext.tsx
+++ b/client/src/contexts/WebSocketContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React, {

--- a/client/src/hooks/useExamplePipelines.ts
+++ b/client/src/hooks/useExamplePipelines.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useEffect } from "react";

--- a/client/src/hooks/useModule.ts
+++ b/client/src/hooks/useModule.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useEffect } from "react";

--- a/client/src/hooks/usePersistPipeline.ts
+++ b/client/src/hooks/usePersistPipeline.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useMemo } from "react";
 import { Node, Edge } from "@xyflow/react";
 import { ModuleData, ModuleType } from "@/types/module";

--- a/client/src/hooks/usePersistPreset.ts
+++ b/client/src/hooks/usePersistPreset.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useCallback, useEffect, useState } from "react";

--- a/client/src/services/apiClient.ts
+++ b/client/src/services/apiClient.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import axios from "axios";
 
 // Add more default headers here if needed

--- a/client/src/services/binaryService.ts
+++ b/client/src/services/binaryService.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { validateConfigFile } from "@/utils/configValidator";
 import { apiClient } from "./apiClient";
 

--- a/client/src/services/pipelineService.ts
+++ b/client/src/services/pipelineService.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import type { PipelineRequest, PipelineResponse } from "@/types/pipeline";
 import { apiClient } from "./apiClient";
 

--- a/client/src/services/videoService.ts
+++ b/client/src/services/videoService.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { apiClient } from "@/services/apiClient";
 import { RefObject } from "react";
 import axios from "axios";

--- a/client/src/types/metrics.ts
+++ b/client/src/types/metrics.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export type Metrics = {
   message?: string;
   psnr?: number;

--- a/client/src/types/module.ts
+++ b/client/src/types/module.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export type ParamValueType = string | number | boolean;
 export type ParamConstraintsType = "str" | "int" | "select" | "bool";
 export const ALLOWED_FRAME_RATES = [

--- a/client/src/types/pipeline.ts
+++ b/client/src/types/pipeline.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ParamValueType } from "@/types/module";
 import { Metrics } from "./metrics";
 import { Edge } from "@xyflow/react";

--- a/client/src/utils/CopyableToast.tsx
+++ b/client/src/utils/CopyableToast.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Button, Typography } from "@mui/material";
 import { toast } from "react-toastify/unstyled";
 

--- a/client/src/utils/UndoToast.tsx
+++ b/client/src/utils/UndoToast.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Button } from "@mui/material";
 import { toast } from "react-toastify/unstyled";
 

--- a/client/src/utils/camelize.ts
+++ b/client/src/utils/camelize.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export function camelizeKeys<T>(value: T): T {
   if (Array.isArray(value)) {
     // Recurse into arrays

--- a/client/src/utils/configValidator.ts
+++ b/client/src/utils/configValidator.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ALLOWED_FRAME_RATES, FrameRate, IOFormat } from "@/types/module";
 import { camelizeKeys } from "./camelize";
 

--- a/client/src/utils/pipelineSerializer.ts
+++ b/client/src/utils/pipelineSerializer.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Node, Edge } from "@xyflow/react";
 import {
   PipelineModule,

--- a/client/src/utils/sharedFunctionality.ts
+++ b/client/src/utils/sharedFunctionality.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import crypto from "crypto";
 import stringify from "json-stable-stringify";
 import type { PipelineData, ProtectedExport } from "./types";

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // types.ts (or shareFunctionality.ts)
 import type { Node, Edge } from "@xyflow/react";
 

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /** @type {import("tailwindcss").Config} */
 module.exports = {
   content: [

--- a/client/tests/unit/contexts/VideoMetricsContext.test.tsx
+++ b/client/tests/unit/contexts/VideoMetricsContext.test.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from "react";
 import { renderHook, act } from "@testing-library/react";
 import {

--- a/client/tests/unit/contexts/VideoReloadContext.test.tsx
+++ b/client/tests/unit/contexts/VideoReloadContext.test.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from "react";
 import { renderHook, act } from "@testing-library/react";
 import {

--- a/client/tests/unit/helpers/helpers.ts
+++ b/client/tests/unit/helpers/helpers.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Node } from "@xyflow/react";
 import { Position } from "@xyflow/react";
 import { ModuleData, ModuleParameter } from "@/types/module";

--- a/client/tests/unit/hooks/useModule.test.ts
+++ b/client/tests/unit/hooks/useModule.test.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { renderHook, waitFor } from "@testing-library/react";
 import { useModules } from "@/hooks/useModule";
 import { apiClient } from "@/services/apiClient";

--- a/client/tests/unit/services/videoService.test.ts
+++ b/client/tests/unit/services/videoService.test.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { loadVideo } from "@/services/videoService";
 import { apiClient } from "@/services/apiClient";
 

--- a/client/tests/unit/utils/camelize.test.ts
+++ b/client/tests/unit/utils/camelize.test.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { camelizeKeys } from "@/utils/camelize";
 import type { Module } from "@/types/module";
 

--- a/client/tests/unit/utils/pipelineSerializer.test.ts
+++ b/client/tests/unit/utils/pipelineSerializer.test.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { dumpPipelineToJson } from "@/utils/pipelineSerializer";
 import { makeNode } from "../helpers/helpers";
 import type { Edge } from "@xyflow/react";

--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/db/convert_json_to_modules.py
+++ b/server/app/db/convert_json_to_modules.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import uuid
 from pathlib import Path

--- a/server/app/modules/__init__.py
+++ b/server/app/modules/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/modules/generic/binary_module.py
+++ b/server/app/modules/generic/binary_module.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from app.modules.module import ModuleBase
 from typing import Any, override

--- a/server/app/modules/inputs/video_source.py
+++ b/server/app/modules/inputs/video_source.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import contextlib
 from typing import Any, Iterator, override
 import cv2

--- a/server/app/modules/module.py
+++ b/server/app/modules/module.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from typing import Any
 from pydantic import BaseModel, Field, ConfigDict

--- a/server/app/modules/outputs/video_output.py
+++ b/server/app/modules/outputs/video_output.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
 from typing import Any, Iterator, override
 import cv2

--- a/server/app/modules/transforms/blur.py
+++ b/server/app/modules/transforms/blur.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import cv2
 from typing import Any, override
 from pathlib import Path

--- a/server/app/modules/transforms/color.py
+++ b/server/app/modules/transforms/color.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import cv2
 from typing import Any, override
 from pathlib import Path

--- a/server/app/modules/transforms/resize.py
+++ b/server/app/modules/transforms/resize.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import cv2
 from typing import Any, override
 from pathlib import Path

--- a/server/app/modules/utils/enums.py
+++ b/server/app/modules/utils/enums.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 
 

--- a/server/app/routers/__init__.py
+++ b/server/app/routers/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/routers/binaries.py
+++ b/server/app/routers/binaries.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from fastapi import APIRouter
 from typing import Any

--- a/server/app/routers/frame.py
+++ b/server/app/routers/frame.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from contextlib import ExitStack
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pathlib import Path

--- a/server/app/routers/modules.py
+++ b/server/app/routers/modules.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from fastapi import HTTPException, UploadFile, APIRouter, File
 import json
 from pathlib import Path

--- a/server/app/routers/pipeline.py
+++ b/server/app/routers/pipeline.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from fastapi import APIRouter, HTTPException
 from pydantic import ValidationError
 from app.schemas.pipeline import PipelineRequest, PipelineResponse

--- a/server/app/routers/video.py
+++ b/server/app/routers/video.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 from pathlib import Path

--- a/server/app/schemas/__init__.py
+++ b/server/app/schemas/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/schemas/frame.py
+++ b/server/app/schemas/frame.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel
 from app.schemas.metrics import Metrics
 

--- a/server/app/schemas/metrics.py
+++ b/server/app/schemas/metrics.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel
 
 

--- a/server/app/schemas/module.py
+++ b/server/app/schemas/module.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing import Any
 from app.modules.utils.enums import Color, ColorSpace, FrameRate, PixelFormat

--- a/server/app/schemas/pipeline.py
+++ b/server/app/schemas/pipeline.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel
 from app.schemas.metrics import Metrics
 from app.schemas.module import ModuleData

--- a/server/app/schemas/video.py
+++ b/server/app/schemas/video.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel
 
 

--- a/server/app/services/__init__.py
+++ b/server/app/services/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/services/binaries.py
+++ b/server/app/services/binaries.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import urllib.request
 import json
 import pathlib

--- a/server/app/services/module_registry.py
+++ b/server/app/services/module_registry.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from app.modules.module import ModuleBase
 
 

--- a/server/app/services/modules.py
+++ b/server/app/services/modules.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any
 from pathlib import Path
 import json

--- a/server/app/services/pipeline.py
+++ b/server/app/services/pipeline.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from collections import defaultdict, deque
 from typing import Any, Iterator

--- a/server/app/utils/constants.py
+++ b/server/app/utils/constants.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Supported video formats and their media types
 VIDEO_TYPES = {
     ".mp4": "video/mp4",

--- a/server/app/utils/enums.py
+++ b/server/app/utils/enums.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 
 

--- a/server/app/utils/quality_metrics.py
+++ b/server/app/utils/quality_metrics.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import cv2
 import numpy as np
 from skimage.metrics import structural_similarity as ssim  # type: ignore

--- a/server/app/utils/shared_functionality.py
+++ b/server/app/utils/shared_functionality.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
 import typing
 import contextlib

--- a/server/main.py
+++ b/server/main.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware

--- a/server/tests/test_binaries.py
+++ b/server/tests/test_binaries.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from typing import Any
 from unittest.mock import patch, MagicMock, mock_open


### PR DESCRIPTION
## Summary

Fixes open source compliance issues by conforming to the [Cisco oss-template](https://github.com/cisco-ospo/oss-template)

## Description

- Add Apache 2 license
- Add CONTRIBUTING.md with guidelines for contributors
- Add SECURITY.md with security policies and vulnerability reporting
- Add CODE_OF_CONDUCT.md with Contributor Covenant Code of Conduct
- Updated enforcement contacts
- Add SPDX license+copyright headers to source files
- Refactor README per oss-template


### Motivation and Context

Cisco OSPO compliance

