### PR TITLE
fix: add spdx headers to source files

### DIFF
--- a/client/jest.config.ts
+++ b/client/jest.config.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import nextJest from "next/jest";
 import type { Config } from "jest";
 

--- a/client/jest.setup.ts
+++ b/client/jest.setup.ts
@@ -1,1 +1,5 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import "@testing-library/jest-dom";

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2025 Cisco Systems, Inc. and its affiliates
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @layer theme, base, mui, components, utilities;
 @import "tailwindcss";
 @import "@xyflow/react/dist/style.css";

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import "./globals.css";
 import { Suspense } from "react";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter";

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import DragAndDropArea from "@/components/cards/DragAndDropArea";
 import AppLayout from "@/components/layout/AppLayout";
 import { Box } from "@mui/material";

--- a/client/src/components/cards/DragAndDropArea.tsx
+++ b/client/src/components/cards/DragAndDropArea.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import FlowCanvas from "@/components/drag-and-drop/FlowCanvas";

--- a/client/src/components/cards/VideoComparisonView.tsx
+++ b/client/src/components/cards/VideoComparisonView.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState } from "react";

--- a/client/src/components/comparison-metrics/VideoQualityMetrics.tsx
+++ b/client/src/components/comparison-metrics/VideoQualityMetrics.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useVideoMetrics } from "@/contexts/VideoMetricsContext";
 import { Box } from "@mui/material";
 import { useMemo } from "react";

--- a/client/src/components/comparison-view/FrameStreamPlayer.tsx
+++ b/client/src/components/comparison-view/FrameStreamPlayer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React, { useCallback, useEffect, useRef, useState } from "react";

--- a/client/src/components/comparison-view/InterleavingFrames.tsx
+++ b/client/src/components/comparison-view/InterleavingFrames.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useEffect, useRef, useState } from "react";

--- a/client/src/components/comparison-view/MenuDropdown.tsx
+++ b/client/src/components/comparison-view/MenuDropdown.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState } from "react";

--- a/client/src/components/comparison-view/PlayerControls.tsx
+++ b/client/src/components/comparison-view/PlayerControls.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import {

--- a/client/src/components/comparison-view/SideBySide.tsx
+++ b/client/src/components/comparison-view/SideBySide.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useRef, useEffect } from "react";

--- a/client/src/components/comparison-view/UnifiedPlayer.tsx
+++ b/client/src/components/comparison-view/UnifiedPlayer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React from "react";

--- a/client/src/components/comparison-view/VideoPlayer.tsx
+++ b/client/src/components/comparison-view/VideoPlayer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React, {

--- a/client/src/components/comparison-view/types.ts
+++ b/client/src/components/comparison-view/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Metrics } from "@/types/metrics";
 
 export enum ViewOptions {

--- a/client/src/components/drag-and-drop/ExamplePipelines.tsx
+++ b/client/src/components/drag-and-drop/ExamplePipelines.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useReactFlow } from "@xyflow/react";

--- a/client/src/components/drag-and-drop/FlowCanvas.tsx
+++ b/client/src/components/drag-and-drop/FlowCanvas.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React, { useCallback, useRef, useMemo, useState } from "react";

--- a/client/src/components/drag-and-drop/FlowNode.tsx
+++ b/client/src/components/drag-and-drop/FlowNode.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Handle, Node, NodeProps, Position } from "@xyflow/react";

--- a/client/src/components/drag-and-drop/ModuleItem.tsx
+++ b/client/src/components/drag-and-drop/ModuleItem.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 import { Box } from "@mui/material";
 import { Module } from "@/types/module";

--- a/client/src/components/drag-and-drop/ModuleItemGroup.tsx
+++ b/client/src/components/drag-and-drop/ModuleItemGroup.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Divider } from "@mui/material";
 import ModuleItem from "./ModuleItem";
 import { Module } from "@/types/module";

--- a/client/src/components/drag-and-drop/Modules.tsx
+++ b/client/src/components/drag-and-drop/Modules.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Divider, InputAdornment, Stack, TextField } from "@mui/material";
 import { useMemo, useState } from "react";
 import { useModulesContext } from "@/contexts/ModulesContext";

--- a/client/src/components/drag-and-drop/context-menu/CanvasContextMenu.tsx
+++ b/client/src/components/drag-and-drop/context-menu/CanvasContextMenu.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useCallback, useImperativeHandle, useRef, useState } from "react";
 import { useCanvasActions } from "./useCanvasActions";
 import {

--- a/client/src/components/drag-and-drop/context-menu/CanvasContextMenuConfig.tsx
+++ b/client/src/components/drag-and-drop/context-menu/CanvasContextMenuConfig.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   Add,
   DeleteOutlined,

--- a/client/src/components/drag-and-drop/context-menu/NodeContextMenu.tsx
+++ b/client/src/components/drag-and-drop/context-menu/NodeContextMenu.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   useCallback,
   useImperativeHandle,

--- a/client/src/components/drag-and-drop/context-menu/NodeContextMenuConfig.tsx
+++ b/client/src/components/drag-and-drop/context-menu/NodeContextMenuConfig.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ContextMenuItem } from "@/components/util/types";
 import {
   FileCopyOutlined,

--- a/client/src/components/drag-and-drop/context-menu/useCanvasActions.ts
+++ b/client/src/components/drag-and-drop/context-menu/useCanvasActions.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useCallback, useContext } from "react";
 import { CanvasContextAction } from "./CanvasContextMenuConfig";
 import { useReactFlow } from "@xyflow/react";

--- a/client/src/components/drag-and-drop/context-menu/useNodeActions.ts
+++ b/client/src/components/drag-and-drop/context-menu/useNodeActions.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useReactFlow, Node, Edge, getConnectedEdges } from "@xyflow/react";
 import { NodeAction } from "./NodeContextMenuConfig";
 import { useCallback } from "react";

--- a/client/src/components/drag-and-drop/parameter-configuration/ParameterConfiguration.tsx
+++ b/client/src/components/drag-and-drop/parameter-configuration/ParameterConfiguration.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useMemo } from "react";

--- a/client/src/components/drag-and-drop/parameter-configuration/ParameterConfigurationDrawer.tsx
+++ b/client/src/components/drag-and-drop/parameter-configuration/ParameterConfigurationDrawer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useCallback, useEffect, useState } from "react";

--- a/client/src/components/drag-and-drop/parameter-configuration/ParameterTooltip.tsx
+++ b/client/src/components/drag-and-drop/parameter-configuration/ParameterTooltip.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import Tooltip from "@mui/material/Tooltip";
 import { ReactElement } from "react";
 

--- a/client/src/components/drag-and-drop/types.ts
+++ b/client/src/components/drag-and-drop/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Node } from "@xyflow/react";
 import { ParamValueType, ModuleType, ModuleData } from "@/types/module";
 

--- a/client/src/components/drag-and-drop/util.ts
+++ b/client/src/components/drag-and-drop/util.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Edge, Node } from "@xyflow/react";
 import { ModuleData, ModuleParameter, ModuleType } from "@/types/module";
 import { displayError } from "@/utils/sharedFunctionality";

--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 import { useState } from "react";
 import { Sidebar } from "../sidebar/Sidebar";

--- a/client/src/components/layout/Loading.tsx
+++ b/client/src/components/layout/Loading.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Box, CircularProgress } from "@mui/material";

--- a/client/src/components/modals/DualFileRow.tsx
+++ b/client/src/components/modals/DualFileRow.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Button, Typography, Paper, Box } from "@mui/material";

--- a/client/src/components/modals/SingleFileRow.tsx
+++ b/client/src/components/modals/SingleFileRow.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Button, Typography, Paper, Box } from "@mui/material";

--- a/client/src/components/modals/UploadBinaryModal.tsx
+++ b/client/src/components/modals/UploadBinaryModal.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Button, Box } from "@mui/material";

--- a/client/src/components/sidebar/AppDrawer.tsx
+++ b/client/src/components/sidebar/AppDrawer.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { Drawer, Typography, Box, IconButton } from "@mui/material";

--- a/client/src/components/sidebar/LeftSidebar.tsx
+++ b/client/src/components/sidebar/LeftSidebar.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useVideoReload } from "@/contexts/VideoReloadContext";

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 import { Drawer, List, Divider, Box } from "@mui/material";
 import { SidebarItem } from "./SidebarItem";

--- a/client/src/components/sidebar/SidebarItem.tsx
+++ b/client/src/components/sidebar/SidebarItem.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   ListItem,
   ListItemButton,

--- a/client/src/components/sidebar/SidebarPanel.tsx
+++ b/client/src/components/sidebar/SidebarPanel.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Paper, Typography, IconButton, Box } from "@mui/material";
 import { Close } from "@mui/icons-material";
 import { SidebarPanelProps } from "./types";

--- a/client/src/components/sidebar/sidebar-config.tsx
+++ b/client/src/components/sidebar/sidebar-config.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   QueryStatsOutlined,
   FilterAltOutlined,

--- a/client/src/components/sidebar/types.ts
+++ b/client/src/components/sidebar/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { SxProps, Theme } from "@mui/material";
 import { ReactNode } from "react";
 

--- a/client/src/components/sidebar/util.ts
+++ b/client/src/components/sidebar/util.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useMemo } from "react";
 import { useVideoReload } from "@/contexts/VideoReloadContext";
 import { toast } from "react-toastify/unstyled";

--- a/client/src/components/util/ContextMenu.tsx
+++ b/client/src/components/util/ContextMenu.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { ListItemIcon, ListItemText, Divider } from "@mui/material";

--- a/client/src/components/util/GenericModal.tsx
+++ b/client/src/components/util/GenericModal.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import {

--- a/client/src/components/util/types.ts
+++ b/client/src/components/util/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ButtonOwnProps } from "@mui/material";
 
 export type ContextMenuItem<ActionType extends string> = {

--- a/client/src/contexts/AppProviders.tsx
+++ b/client/src/contexts/AppProviders.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ReactNode } from "react";
 import { VideoMetricsProvider } from "./VideoMetricsContext";
 import { VideoReloadProvider } from "./VideoReloadContext";

--- a/client/src/contexts/ExamplePipelinesContext.tsx
+++ b/client/src/contexts/ExamplePipelinesContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { createContext, useMemo, ReactNode, useContext } from "react";

--- a/client/src/contexts/ModulesContext.tsx
+++ b/client/src/contexts/ModulesContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useModules } from "@/hooks/useModule";

--- a/client/src/contexts/SidebarContext.tsx
+++ b/client/src/contexts/SidebarContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { createContext } from "react";
 
 type SidebarContextValue = {

--- a/client/src/contexts/VideoMetricsContext.tsx
+++ b/client/src/contexts/VideoMetricsContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 import { Metrics } from "@/types/metrics";
 import React, { createContext, useContext, useState } from "react";

--- a/client/src/contexts/VideoReloadContext.tsx
+++ b/client/src/contexts/VideoReloadContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import {

--- a/client/src/contexts/WebSocketContext.tsx
+++ b/client/src/contexts/WebSocketContext.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import React, {

--- a/client/src/hooks/useExamplePipelines.ts
+++ b/client/src/hooks/useExamplePipelines.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useEffect } from "react";

--- a/client/src/hooks/useModule.ts
+++ b/client/src/hooks/useModule.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useState, useEffect } from "react";

--- a/client/src/hooks/usePersistPipeline.ts
+++ b/client/src/hooks/usePersistPipeline.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useMemo } from "react";
 import { Node, Edge } from "@xyflow/react";
 import { ModuleData, ModuleType } from "@/types/module";

--- a/client/src/hooks/usePersistPreset.ts
+++ b/client/src/hooks/usePersistPreset.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useCallback, useEffect, useState } from "react";

--- a/client/src/services/apiClient.ts
+++ b/client/src/services/apiClient.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import axios from "axios";
 
 // Add more default headers here if needed

--- a/client/src/services/binaryService.ts
+++ b/client/src/services/binaryService.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { validateConfigFile } from "@/utils/configValidator";
 import { apiClient } from "./apiClient";
 

--- a/client/src/services/pipelineService.ts
+++ b/client/src/services/pipelineService.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import type { PipelineRequest, PipelineResponse } from "@/types/pipeline";
 import { apiClient } from "./apiClient";
 

--- a/client/src/services/videoService.ts
+++ b/client/src/services/videoService.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { apiClient } from "@/services/apiClient";
 import { RefObject } from "react";
 import axios from "axios";

--- a/client/src/types/metrics.ts
+++ b/client/src/types/metrics.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export type Metrics = {
   message?: string;
   psnr?: number;

--- a/client/src/types/module.ts
+++ b/client/src/types/module.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export type ParamValueType = string | number | boolean;
 export type ParamConstraintsType = "str" | "int" | "select" | "bool";
 export const ALLOWED_FRAME_RATES = [

--- a/client/src/types/pipeline.ts
+++ b/client/src/types/pipeline.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ParamValueType } from "@/types/module";
 import { Metrics } from "./metrics";
 import { Edge } from "@xyflow/react";

--- a/client/src/utils/CopyableToast.tsx
+++ b/client/src/utils/CopyableToast.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Button, Typography } from "@mui/material";
 import { toast } from "react-toastify/unstyled";
 

--- a/client/src/utils/UndoToast.tsx
+++ b/client/src/utils/UndoToast.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Button } from "@mui/material";
 import { toast } from "react-toastify/unstyled";
 

--- a/client/src/utils/camelize.ts
+++ b/client/src/utils/camelize.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export function camelizeKeys<T>(value: T): T {
   if (Array.isArray(value)) {
     // Recurse into arrays

--- a/client/src/utils/configValidator.ts
+++ b/client/src/utils/configValidator.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { ALLOWED_FRAME_RATES, FrameRate, IOFormat } from "@/types/module";
 import { camelizeKeys } from "./camelize";
 

--- a/client/src/utils/pipelineSerializer.ts
+++ b/client/src/utils/pipelineSerializer.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Node, Edge } from "@xyflow/react";
 import {
   PipelineModule,

--- a/client/src/utils/sharedFunctionality.ts
+++ b/client/src/utils/sharedFunctionality.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import crypto from "crypto";
 import stringify from "json-stable-stringify";
 import type { PipelineData, ProtectedExport } from "./types";

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // types.ts (or shareFunctionality.ts)
 import type { Node, Edge } from "@xyflow/react";
 

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /** @type {import("tailwindcss").Config} */
 module.exports = {
   content: [

--- a/client/tests/unit/contexts/VideoMetricsContext.test.tsx
+++ b/client/tests/unit/contexts/VideoMetricsContext.test.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from "react";
 import { renderHook, act } from "@testing-library/react";
 import {

--- a/client/tests/unit/contexts/VideoReloadContext.test.tsx
+++ b/client/tests/unit/contexts/VideoReloadContext.test.tsx
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from "react";
 import { renderHook, act } from "@testing-library/react";
 import {

--- a/client/tests/unit/helpers/helpers.ts
+++ b/client/tests/unit/helpers/helpers.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Node } from "@xyflow/react";
 import { Position } from "@xyflow/react";
 import { ModuleData, ModuleParameter } from "@/types/module";

--- a/client/tests/unit/hooks/useModule.test.ts
+++ b/client/tests/unit/hooks/useModule.test.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { renderHook, waitFor } from "@testing-library/react";
 import { useModules } from "@/hooks/useModule";
 import { apiClient } from "@/services/apiClient";

--- a/client/tests/unit/services/videoService.test.ts
+++ b/client/tests/unit/services/videoService.test.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { loadVideo } from "@/services/videoService";
 import { apiClient } from "@/services/apiClient";
 

--- a/client/tests/unit/utils/camelize.test.ts
+++ b/client/tests/unit/utils/camelize.test.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { camelizeKeys } from "@/utils/camelize";
 import type { Module } from "@/types/module";
 

--- a/client/tests/unit/utils/pipelineSerializer.test.ts
+++ b/client/tests/unit/utils/pipelineSerializer.test.ts
@@ -1,3 +1,7 @@
+// Copyright 2025 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { dumpPipelineToJson } from "@/utils/pipelineSerializer";
 import { makeNode } from "../helpers/helpers";
 import type { Edge } from "@xyflow/react";

--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/db/convert_json_to_modules.py
+++ b/server/app/db/convert_json_to_modules.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import uuid
 from pathlib import Path

--- a/server/app/modules/__init__.py
+++ b/server/app/modules/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/modules/generic/binary_module.py
+++ b/server/app/modules/generic/binary_module.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from app.modules.module import ModuleBase
 from typing import Any, override

--- a/server/app/modules/inputs/video_source.py
+++ b/server/app/modules/inputs/video_source.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import contextlib
 from typing import Any, Iterator, override
 import cv2

--- a/server/app/modules/module.py
+++ b/server/app/modules/module.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from typing import Any
 from pydantic import BaseModel, Field, ConfigDict

--- a/server/app/modules/outputs/video_output.py
+++ b/server/app/modules/outputs/video_output.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
 from typing import Any, Iterator, override
 import cv2

--- a/server/app/modules/transforms/blur.py
+++ b/server/app/modules/transforms/blur.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import cv2
 from typing import Any, override
 from pathlib import Path

--- a/server/app/modules/transforms/color.py
+++ b/server/app/modules/transforms/color.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import cv2
 from typing import Any, override
 from pathlib import Path

--- a/server/app/modules/transforms/resize.py
+++ b/server/app/modules/transforms/resize.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import cv2
 from typing import Any, override
 from pathlib import Path

--- a/server/app/modules/utils/enums.py
+++ b/server/app/modules/utils/enums.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 
 

--- a/server/app/routers/__init__.py
+++ b/server/app/routers/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/routers/binaries.py
+++ b/server/app/routers/binaries.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from fastapi import APIRouter
 from typing import Any

--- a/server/app/routers/frame.py
+++ b/server/app/routers/frame.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from contextlib import ExitStack
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pathlib import Path

--- a/server/app/routers/modules.py
+++ b/server/app/routers/modules.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from fastapi import HTTPException, UploadFile, APIRouter, File
 import json
 from pathlib import Path

--- a/server/app/routers/pipeline.py
+++ b/server/app/routers/pipeline.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from fastapi import APIRouter, HTTPException
 from pydantic import ValidationError
 from app.schemas.pipeline import PipelineRequest, PipelineResponse

--- a/server/app/routers/video.py
+++ b/server/app/routers/video.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 from pathlib import Path

--- a/server/app/schemas/__init__.py
+++ b/server/app/schemas/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/schemas/frame.py
+++ b/server/app/schemas/frame.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel
 from app.schemas.metrics import Metrics
 

--- a/server/app/schemas/metrics.py
+++ b/server/app/schemas/metrics.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel
 
 

--- a/server/app/schemas/module.py
+++ b/server/app/schemas/module.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing import Any
 from app.modules.utils.enums import Color, ColorSpace, FrameRate, PixelFormat

--- a/server/app/schemas/pipeline.py
+++ b/server/app/schemas/pipeline.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel
 from app.schemas.metrics import Metrics
 from app.schemas.module import ModuleData

--- a/server/app/schemas/video.py
+++ b/server/app/schemas/video.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel
 
 

--- a/server/app/services/__init__.py
+++ b/server/app/services/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/server/app/services/binaries.py
+++ b/server/app/services/binaries.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import urllib.request
 import json
 import pathlib

--- a/server/app/services/module_registry.py
+++ b/server/app/services/module_registry.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from app.modules.module import ModuleBase
 
 

--- a/server/app/services/modules.py
+++ b/server/app/services/modules.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any
 from pathlib import Path
 import json

--- a/server/app/services/pipeline.py
+++ b/server/app/services/pipeline.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from collections import defaultdict, deque
 from typing import Any, Iterator

--- a/server/app/utils/constants.py
+++ b/server/app/utils/constants.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Supported video formats and their media types
 VIDEO_TYPES = {
     ".mp4": "video/mp4",

--- a/server/app/utils/enums.py
+++ b/server/app/utils/enums.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 
 

--- a/server/app/utils/quality_metrics.py
+++ b/server/app/utils/quality_metrics.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import cv2
 import numpy as np
 from skimage.metrics import structural_similarity as ssim  # type: ignore

--- a/server/app/utils/shared_functionality.py
+++ b/server/app/utils/shared_functionality.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
 import typing
 import contextlib

--- a/server/main.py
+++ b/server/main.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware

--- a/server/tests/test_binaries.py
+++ b/server/tests/test_binaries.py
@@ -1,3 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from typing import Any
 from unittest.mock import patch, MagicMock, mock_open


### PR DESCRIPTION
## Summary

Add spdx copyright and license headers to source files per OSPO compliance

## Description

Each source code file needs Cisco copyright and SPDX license headers

### Motivation and Context

Open source policy compliance
